### PR TITLE
Fix OKLCH hue precision to support decimal values

### DIFF
--- a/src/core/services/color-convert-service.ts
+++ b/src/core/services/color-convert-service.ts
@@ -197,7 +197,7 @@ export class ColorConvertService {
       case 'oklch': {
         const oklch = converter('oklch')(parsed) as any;
         if (!oklch) throw new Error('Conversion to oklch failed');
-        return `oklch(${Number(oklch.l?.toFixed(2))} ${Number(oklch.c?.toFixed(2))} ${Math.round(oklch.h ?? 0)})`;
+        return `oklch(${Number(oklch.l?.toFixed(2))} ${Number(oklch.c?.toFixed(2))} ${Number((oklch.h ?? 0).toFixed(2))})`;
       }
       case 'lab': {
         const lab = converter('lab')(parsed) as any;


### PR DESCRIPTION
## Summary
- Updated OKLCH output formatting to preserve decimal precision in hue values instead of rounding to integers
- Aligns with W3C CSS Color Module Level 4 specification which allows hue as `<number>` or `<angle>` including decimals

## Changes
- Modified `color-convert-service.ts:200` to use `toFixed(2)` instead of `Math.round()` for hue values
- Maintains 2 decimal places precision for more accurate color representation

## Test plan
- [x] All existing tests pass
- [x] OKLCH hue values now preserve decimal precision as per official specification

🤖 Generated with [Claude Code](https://claude.ai/code)